### PR TITLE
Issue151 - Tooltip Fixes

### DIFF
--- a/CanvasOverlay.js
+++ b/CanvasOverlay.js
@@ -108,6 +108,8 @@ function backToMap() {
   $("#fractionBackImg").hide();
   $("#numInvalidTooltip").hide();
   $("#denomInvalidTooltip").hide();
+  $("#fracSumNum").val("");
+  $("#fracSumDenom").val("");
   showFractionBox = false;
 }
 /*Sets up all the tooltips and their functionality*/

--- a/game.pde
+++ b/game.pde
@@ -1207,6 +1207,9 @@ void nextMap(){
 void resetHUD(){
 	$("#fuelElement2").css("color","white");
 	$("#fuelNeedle").css("transform","rotate(0deg)");
+    if(showFractionBox){
+        backToMap();
+    }
 }
 /*
     Returns a map to its original state, returns the player to the start point,

--- a/index.html
+++ b/index.html
@@ -74,8 +74,7 @@
     <div id="newMapTooltip" class="tooltip"> </div>
     <div id="resetTooltip" class="tooltip"> </div>
     <div id="fuelTooltip" class="tooltip"></div>
-    <div id="numInvalidTooltip" class="tooltip"></div>
-    <div id="denomInvalidTooltip" class="tooltip"></div>
+
     <!-- End tooltips -->
     <canvas onmouseenter="$('canvas').focus()" data-processing-sources="codebase.pde assetPreloader.pde game.pde"></canvas>
     <div id="cashAnimDiv" class="inCanvas cashAnimBox hidden" >
@@ -120,6 +119,8 @@
       <div id="fractionBackImg" class="hidden" style="position:absolute;left:370px;top:423px;" onclick="backToMap()">
         <img src="./assets/items/alter_btn.png" alt="Alter Route" width="200px" height="50px" />
       </div>
+      <div id="numInvalidTooltip" class="tooltip"></div>
+      <div id="denomInvalidTooltip" class="tooltip"></div>
     </div>
     <div id="tutorialTextDiv" class="textBox hidden inCanvas" style="position:fixed;left:200px;top:500px;width:500px;height:110px;">
         <p id="tutorialTextElement">

--- a/pde/ScreenController.pde
+++ b/pde/ScreenController.pde
@@ -29,6 +29,9 @@ void nextMap(){
 void resetHUD(){
 	$("#fuelElement2").css("color","white");
 	$("#fuelNeedle").css("transform","rotate(0deg)");
+    if(showFractionBox){
+        backToMap();
+    }
 }
 /*
     Returns a map to its original state, returns the player to the start point,


### PR DESCRIPTION
References #151 

Top bar button tooltips are apparently working fine. Don't know what was happening in the presentation.
Fixed fraction sum tooltips persisting through map resets.
Set the fraction sum to blank after hiding the fraction box, so previous answer doesn't appear again.
